### PR TITLE
Add minimal CMake build system + cover compilation with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v3 or later
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,85 @@
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v3 or later
+
+name: Build on Linux
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 3 * * 5'  # Every Friday at 3am
+
+jobs:
+  linux:
+    name: Build (${{ matrix.cc }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: gcc-11
+            cxx: g++-11
+            clang_major_version: null
+            clang_repo_suffix: null
+            runs-on: ubuntu-22.04
+          - cc: gcc-12
+            cxx: g++-12
+            clang_major_version: null
+            clang_repo_suffix: null
+            runs-on: ubuntu-22.04
+          - cc: clang-15
+            cxx: clang++-15
+            clang_major_version: 15
+            clang_repo_suffix: -15
+            runs-on: ubuntu-22.04
+          - cc: clang-16
+            cxx: clang++-16
+            clang_major_version: 16
+            clang_repo_suffix: -16
+            runs-on: ubuntu-22.04
+          - cc: clang-17
+            cxx: clang++-17
+            clang_major_version: 17
+            clang_repo_suffix:
+            runs-on: ubuntu-22.04
+    steps:
+      - name: Add Clang/LLVM repositories
+        if: "${{ contains(matrix.cxx, 'clang') }}"
+        run: |-
+          set -x
+          source /etc/os-release
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}${{ matrix.clang_repo_suffix }} main"
+
+      - name: Install build dependencies
+        run: |-
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            cmake \
+            libsfml-dev \
+            pkg-config
+
+      - name: Install build dependency Clang ${{ matrix.clang_major_version }}
+        if: "${{ contains(matrix.cxx, 'clang') }}"
+        run: |-
+          sudo apt-get install --yes --no-install-recommends -V \
+              clang-${{ matrix.clang_major_version }}
+
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: 'Configure with CMake'
+        run: |-
+          cmake_args=(
+            -DCMAKE_C_COMPILER="${{ matrix.cc }}"
+            -DCMAKE_CXX_COMPILER="${{ matrix.cxx }}"
+            -S ./
+            -B build/
+          )
+          set -x
+          cmake "${cmake_args[@]}"
+
+      - name: 'Build'
+        run: |-
+          set -x
+          make -C build -j$(nproc) VERBOSE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v3 or later
+
+cmake_minimum_required(VERSION 3.6)
+# CMake features used that need more than CMake 3.0:
+# - pkg_check_modules([..] IMPORTED_TARGET [..]) needs >=3.6
+
+project(AudioVisualiser VERSION 9.9.9)
+
+include(FindPkgConfig)
+
+pkg_check_modules(SFML sfml-all REQUIRED IMPORTED_TARGET)
+
+add_executable(AudioVisualiser
+    Code/Headerss/Menu.h
+    Code/Headerss/Modes.h
+    Code/Headerss/SongDatabase.h
+    Code/Headerss/Vizualizer.h
+    Code/Source\ Code/AudioVizualizer.cpp
+    Code/Source\ Code/Buttons.cpp
+    Code/Source\ Code/Menu.cpp
+    Code/Source\ Code/Modes.cpp
+    Code/Source\ Code/SongDatabase.cpp
+    Code/Source\ Code/Vizualizer.cpp
+)
+
+target_link_libraries(AudioVisualiser
+    PUBLIC
+    PkgConfig::SFML
+)

--- a/Code/Headerss/Menu.h
+++ b/Code/Headerss/Menu.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include "SongDatabase.h"

--- a/Code/Headerss/Vizualizer.h
+++ b/Code/Headerss/Vizualizer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <SFML/Window.hpp>
 #include <SFML/Graphics.hpp>
 #include "Menu.h"


### PR DESCRIPTION
Hi! :wave: 

This pull request does four small interconnected things:
- Add a small CMake-based build system. CMake >=3.6 to be precise.
- Add a GitHub Action to build the code on Ubuntu Linux with recent GCC 11/12 and Clang 15/16/17. This will make sure that if the code starts failing to compile in the future we will know and have a chance to react. Example output can be seen at https://github.com/hartwork/AudioVisualiser/actions in my fork of this repository.
- Add a missing include `#include <memory>` to fix compilation for all of these^^ except GCC 11. Compilers get stricter over time.
- Activate GitHub Dependabot to keepu our Github Actions up to date so that I will create pull requests like https://github.com/uriparser/uriparser/pull/159 for us in the future

Regarding the license of the new files, I have put in "Licensed under GPL v3 or later" for the moment, but I'm happy to put in some other license that is Open Source according to OSI and Free Software according to the FSF, e.g. BSD, MIT, Apache 2.
I looked for mention of "copyright" and "license" in here and didn't find any for your own code. Would be great if we could apply some license like that — copyleft or permissive — to that code too. I can make a new pull request on that if you like if you let me know which license and e-mail address to user for the header.

What do you think?

Best, Sebastian